### PR TITLE
Pl/18 add a game state manager autoload

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -15,6 +15,10 @@ config/features=PackedStringArray("4.2", "Forward Plus")
 boot_splash/show_image=false
 config/icon="res://icon.svg"
 
+[autoload]
+
+GameStateManager="*res://scripts/managers/game_state_manager.gd"
+
 [display]
 
 window/size/viewport_width=1920

--- a/scripts/managers/game_state_manager.gd
+++ b/scripts/managers/game_state_manager.gd
@@ -1,0 +1,53 @@
+extends Node
+
+# ====================Public Interface====================
+
+# ---------Signals----------
+
+signal player_died()
+
+@export var initial_player_max_health: int = 100:
+	get:
+		return initial_player_max_health
+
+	set(new_value):
+		initial_player_max_health = max(0, new_value)
+
+
+
+# ----------Player Health----------
+
+var player_max_health: int:
+	get:
+		return _player_max_health
+
+	set(new_value):
+		_player_max_health = max(0, _player_max_health)
+		player_health = min(player_health, _player_max_health)
+
+
+var player_health: int:
+	get:
+		return _player_health
+
+	set(new_value):
+		_player_health = min(max(0, new_value), player_max_health)
+		if _player_health == 0:
+			player_died.emit()
+
+
+# ----------Lifetime----------
+
+func initialize_for_scene():
+	player_max_health = initial_player_max_health
+	player_health = player_max_health
+
+
+
+# ====================Private Implementation====================
+
+# ----------Backing Variables----------
+var _player_max_health: int
+var _player_health: int
+
+# ----------Inherited from parent----------

--- a/scripts/managers/game_state_manager.gd
+++ b/scripts/managers/game_state_manager.gd
@@ -2,7 +2,17 @@ extends Node
 
 # ====================Public Interface====================
 
-# ---------Signals----------
+# ----------Lifetime----------
+
+# TODO: load persistent player data (such as highscore)
+
+func initialize_for_scene():
+	player_max_health = initial_player_max_health
+	player_health = player_max_health
+	reset_score()
+	is_paused = false
+
+# ----------Player Health----------
 
 signal player_died()
 
@@ -13,9 +23,6 @@ signal player_died()
 	set(new_value):
 		initial_player_max_health = max(0, new_value)
 
-
-
-# ----------Player Health----------
 
 var player_max_health: int:
 	get:
@@ -36,18 +43,50 @@ var player_health: int:
 			player_died.emit()
 
 
-# ----------Lifetime----------
+# ----------Score----------
 
-func initialize_for_scene():
-	player_max_health = initial_player_max_health
-	player_health = player_max_health
+var current_score: int:
+	get: return _current_score
+
+var high_score: int:
+	get: return _high_score
+
+func add_score(extra_score: int):
+	_current_score += extra_score
+	if _current_score > _high_score:
+		_high_score = _current_score
+
+func reset_score():
+	_current_score = 0
 
 
+# ----------Pausing----------
+
+signal paused()
+signal unpaused()
+
+var is_paused: bool:
+	get:
+		return _is_paused
+
+	set(new_value):
+		if _is_paused == new_value:
+			return
+
+		_is_paused = new_value
+		if _is_paused:
+			paused.emit()
+		else:
+			unpaused.emit()
 
 # ====================Private Implementation====================
 
-# ----------Backing Variables----------
+# ----------Property Backing Variables (should not touch)----------
+
 var _player_max_health: int
 var _player_health: int
 
-# ----------Inherited from parent----------
+var _current_score: int
+var _high_score: int = 0
+
+var _is_paused: bool = false


### PR DESCRIPTION
Merging this PR will give you:
GameStateManager Autoload global variable with the following properties:

- Player Health Properties/Signals
- Score Properties
- Pause State Properties/Signals

The following still need to be implemented:

- Persistency System aka. save/load
- Skills/Upgrades for the current game and overall record (require skill system to be designed)