### PR TITLE
Mole Spawn Animation and Spawn Area

### DIFF
--- a/scenes/levels/grassy_field.tscn
+++ b/scenes/levels/grassy_field.tscn
@@ -1,6 +1,9 @@
-[gd_scene load_steps=2 format=3 uid="uid://ou60btpj1h75"]
+[gd_scene load_steps=3 format=3 uid="uid://ou60btpj1h75"]
 
 [ext_resource type="Texture2D" uid="uid://e8jgg0dvkq6w" path="res://assets/background/grass-background.png" id="1_1dfqm"]
+
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_5j12s"]
+size = Vector2(1595, 624.5)
 
 [node name="GrassyField" type="Node2D"]
 
@@ -8,3 +11,9 @@
 offset_right = 1920.0
 offset_bottom = 1080.0
 texture = ExtResource("1_1dfqm")
+
+[node name="SpawnArea" type="Area2D" parent="."]
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="SpawnArea"]
+position = Vector2(958, 531.75)
+shape = SubResource("RectangleShape2D_5j12s")

--- a/scenes/levels/grassy_field.tscn
+++ b/scenes/levels/grassy_field.tscn
@@ -1,22 +1,24 @@
 [gd_scene load_steps=4 format=3 uid="uid://ou60btpj1h75"]
 
 [ext_resource type="Texture2D" uid="uid://e8jgg0dvkq6w" path="res://assets/background/grass-background.png" id="1_1dfqm"]
+[ext_resource type="Script" path="res://scripts/levels/level.gd" id="1_xxq0y"]
 [ext_resource type="PackedScene" uid="uid://837y17to6u7f" path="res://scenes/managers/mole_spawner.tscn" id="2_4rsdj"]
 
-[sub_resource type="RectangleShape2D" id="RectangleShape2D_5j12s"]
-size = Vector2(1595, 624.5)
-
 [node name="GrassyField" type="Node2D"]
+script = ExtResource("1_xxq0y")
 
 [node name="Background" type="TextureRect" parent="."]
 offset_right = 1920.0
 offset_bottom = 1080.0
 texture = ExtResource("1_1dfqm")
 
-[node name="SpawnArea" type="Area2D" parent="."]
+[node name="SpawnArea" type="ReferenceRect" parent="."]
+offset_left = 124.0
+offset_top = 252.0
+offset_right = 1721.0
+offset_bottom = 877.0
 
-[node name="CollisionShape2D" type="CollisionShape2D" parent="SpawnArea"]
-position = Vector2(958, 531.75)
-shape = SubResource("RectangleShape2D_5j12s")
+[node name="MoleSpawner" parent="." node_paths=PackedStringArray("spawn_area") instance=ExtResource("2_4rsdj")]
+spawn_area = NodePath("../SpawnArea")
 
-[node name="MoleSpawner" parent="." instance=ExtResource("2_4rsdj")]
+[connection signal="mole_spawned" from="MoleSpawner" to="." method="_on_mole_spawned"]

--- a/scenes/levels/grassy_field.tscn
+++ b/scenes/levels/grassy_field.tscn
@@ -1,6 +1,7 @@
-[gd_scene load_steps=3 format=3 uid="uid://ou60btpj1h75"]
+[gd_scene load_steps=4 format=3 uid="uid://ou60btpj1h75"]
 
 [ext_resource type="Texture2D" uid="uid://e8jgg0dvkq6w" path="res://assets/background/grass-background.png" id="1_1dfqm"]
+[ext_resource type="PackedScene" uid="uid://837y17to6u7f" path="res://scenes/managers/mole_spawner.tscn" id="2_4rsdj"]
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_5j12s"]
 size = Vector2(1595, 624.5)
@@ -17,3 +18,5 @@ texture = ExtResource("1_1dfqm")
 [node name="CollisionShape2D" type="CollisionShape2D" parent="SpawnArea"]
 position = Vector2(958, 531.75)
 shape = SubResource("RectangleShape2D_5j12s")
+
+[node name="MoleSpawner" parent="." instance=ExtResource("2_4rsdj")]

--- a/scenes/levels/grassy_field.tscn
+++ b/scenes/levels/grassy_field.tscn
@@ -4,7 +4,7 @@
 
 [node name="GrassyField" type="Node2D"]
 
-[node name="TextureRect" type="TextureRect" parent="."]
+[node name="Background" type="TextureRect" parent="."]
 offset_right = 1920.0
 offset_bottom = 1080.0
 texture = ExtResource("1_1dfqm")

--- a/scenes/managers/mole_spawner.tscn
+++ b/scenes/managers/mole_spawner.tscn
@@ -1,11 +1,12 @@
 [gd_scene load_steps=3 format=3 uid="uid://837y17to6u7f"]
 
 [ext_resource type="Script" path="res://scripts/managers/mole_spawner.gd" id="1_o746x"]
-[ext_resource type="PackedScene" path="res://scenes/mole/placeholder.tscn" id="2_njclh"]
+[ext_resource type="PackedScene" uid="uid://cwosug7qr3qqs" path="res://scenes/mole/mole.tscn" id="2_3dw6r"]
 
 [node name="MoleSpawner" type="Node2D"]
 script = ExtResource("1_o746x")
-spawn_area = Rect2(0, 0, 1920, 1080)
-mole_scene = ExtResource("2_njclh")
+mole_scene = ExtResource("2_3dw6r")
 
 [node name="Timer" type="Timer" parent="."]
+
+[connection signal="timeout" from="Timer" to="." method="_on_timer_timeout"]

--- a/scenes/mole/mole.tscn
+++ b/scenes/mole/mole.tscn
@@ -1,8 +1,76 @@
-[gd_scene load_steps=2 format=3 uid="uid://cwosug7qr3qqs"]
+[gd_scene load_steps=11 format=3 uid="uid://cwosug7qr3qqs"]
+
+[ext_resource type="Texture2D" uid="uid://3000pe1233s5" path="res://assets/mole-hole/mole-hole.png" id="1_5ngfp"]
+[ext_resource type="Script" path="res://scripts/mole/mole.gd" id="1_khpre"]
+[ext_resource type="Texture2D" uid="uid://cwtay2a1pnwbr" path="res://assets/mole/mole.png" id="2_os357"]
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_0xbpt"]
+atlas = ExtResource("1_5ngfp")
+region = Rect2(0, 0, 128, 128)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_d3ap0"]
+atlas = ExtResource("1_5ngfp")
+region = Rect2(128, 0, 128, 128)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_uruej"]
+atlas = ExtResource("1_5ngfp")
+region = Rect2(256, 0, 128, 128)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_thy4l"]
+atlas = ExtResource("1_5ngfp")
+region = Rect2(384, 0, 128, 128)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_u0wwa"]
+atlas = ExtResource("1_5ngfp")
+region = Rect2(512, 0, 128, 128)
 
 [sub_resource type="SpriteFrames" id="SpriteFrames_apu38"]
+animations = [{
+"frames": [{
+"duration": 1.0,
+"texture": null
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_0xbpt")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_d3ap0")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_uruej")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_thy4l")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_u0wwa")
+}],
+"loop": false,
+"name": &"emerge",
+"speed": 12.0
+}, {
+"frames": [{
+"duration": 1.0,
+"texture": ExtResource("2_os357")
+}],
+"loop": false,
+"name": &"idle",
+"speed": 1.0
+}]
 
-[node name="Mole" type="Node2D"]
+[sub_resource type="CapsuleShape2D" id="CapsuleShape2D_6gxtq"]
+radius = 35.0
+height = 86.0
+
+[node name="Mole" type="CharacterBody2D"]
+script = ExtResource("1_khpre")
 
 [node name="AnimatedSprite2D" type="AnimatedSprite2D" parent="."]
 sprite_frames = SubResource("SpriteFrames_apu38")
+animation = &"idle"
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="."]
+position = Vector2(0, -4)
+shape = SubResource("CapsuleShape2D_6gxtq")
+
+[connection signal="animation_finished" from="AnimatedSprite2D" to="." method="_on_animation_finished"]

--- a/scenes/mole/mole.tscn
+++ b/scenes/mole/mole.tscn
@@ -1,0 +1,8 @@
+[gd_scene load_steps=2 format=3 uid="uid://cwosug7qr3qqs"]
+
+[sub_resource type="SpriteFrames" id="SpriteFrames_apu38"]
+
+[node name="Mole" type="Node2D"]
+
+[node name="AnimatedSprite2D" type="AnimatedSprite2D" parent="."]
+sprite_frames = SubResource("SpriteFrames_apu38")

--- a/scripts/levels/level.gd
+++ b/scripts/levels/level.gd
@@ -1,0 +1,16 @@
+class_name Level extends Node
+
+## level.gd: This script manages adding spawned moles to the level scene.
+##
+## Author(s): Tessa Power
+
+@onready var spawn_timer = $MoleSpawner/Timer
+
+func _ready() -> void:
+	spawn_timer.start()
+
+
+func _on_mole_spawned(mole: Mole, position: Vector2) -> void:
+	mole.set_global_position(position)
+	#print("spawned mole at:", mole.global_position)
+	add_child(mole)

--- a/scripts/managers/mole_spawner.gd
+++ b/scripts/managers/mole_spawner.gd
@@ -2,33 +2,27 @@ extends Node
 
 # ====================Public Interface====================
 
-@export var spawn_area: Rect2
+@export var spawn_area: Area2D
 @export var mole_scene: PackedScene
 
-@onready var spawn_timer: Timer = $Timer
-
-signal mole_spawned(mole: Node2D, position: Vector2)
+signal mole_spawned(mole: Mole, position: Vector2)
 
 func spawn_mole():
 	mole_spawned.emit(
-		mole_scene.instantiate() as Node2D,
-		_get_random_spawn_point());
+		mole_scene.instantiate() as Mole,
+		_get_random_spawn_point())
 
 # ====================Internal details====================
 
-# ----------Inherited from parent---------- 
+# ----------Inherited from parent----------
 
-# Called when the node enters the scene tree for the first time.
 func _ready():
 	# Assertions
-	assert(spawn_timer != null)
 	assert(mole_scene != null)
-
-	spawn_timer.timeout.connect(_on_spawn_timer_timeouted)
 
 # ----------Callbacks----------
 
-func _on_spawn_timer_timeouted():
+func _on_timer_timeout():
 	spawn_mole()
 
 # ----------Private Implementations----------
@@ -36,4 +30,4 @@ func _on_spawn_timer_timeouted():
 func _get_random_spawn_point() -> Vector2:
 	return Vector2(
 		randf_range(spawn_area.position.x, spawn_area.end.x),
-		randf_range(spawn_area.position.y, spawn_area.end.y));
+		randf_range(spawn_area.position.y, spawn_area.end.y))

--- a/scripts/managers/mole_spawner.gd
+++ b/scripts/managers/mole_spawner.gd
@@ -2,7 +2,10 @@ extends Node
 
 # ====================Public Interface====================
 
-@export var spawn_area: Area2D
+## A [code]ReferenceRect[/code] which outlines where moles can be spawned.
+@export var spawn_area: ReferenceRect
+
+## The mole scene to be spawned.
 @export var mole_scene: PackedScene
 
 signal mole_spawned(mole: Mole, position: Vector2)
@@ -16,9 +19,17 @@ func spawn_mole():
 
 # ----------Inherited from parent----------
 
+var spawn_area_start: Vector2
+var spawn_area_end: Vector2
+
 func _ready():
 	# Assertions
 	assert(mole_scene != null)
+	assert(spawn_area != null)
+	spawn_area_start = spawn_area.get_global_position()
+	spawn_area_end = spawn_area_start + spawn_area.size
+
+
 
 # ----------Callbacks----------
 
@@ -29,5 +40,5 @@ func _on_timer_timeout():
 
 func _get_random_spawn_point() -> Vector2:
 	return Vector2(
-		randf_range(spawn_area.position.x, spawn_area.end.x),
-		randf_range(spawn_area.position.y, spawn_area.end.y))
+		randf_range(spawn_area_start.x, spawn_area_end.x),
+		randf_range(spawn_area_start.y, spawn_area_end.y))

--- a/scripts/mole/mole.gd
+++ b/scripts/mole/mole.gd
@@ -1,0 +1,18 @@
+class_name Mole extends CharacterBody2D
+## mole.gd: Controls the mole enemy character.
+##
+## Author(s): Tessa Power
+
+## Animations
+@onready var animated_sprite = $AnimatedSprite2D
+
+func _ready() -> void:
+	animated_sprite.play("emerge")
+
+
+## Callback function for when the mole's animated sprite finishes an animation,
+## and sets the next animation appropriately.
+func _on_animation_finished() -> void:
+	match animated_sprite.animation:
+		"emerge":
+			animated_sprite.play("idle")


### PR DESCRIPTION
Merging this PR will:

- Add a new mole scene.
- Add the mole spawning animation to the mole scene.
- Refactor the mole spawner to support spawning moles within a rectangular area in a level scene.
- Add a `ReferenceRect` to the grassy field scene that indicates the spawn area.
- Add the mole spawner to the grassy field scene.
- Introduce a level script that supports added spawned moles to a level scene.

Closes #3.