### PR TITLE
Mole Animation Tweaks

### DIFF
--- a/scenes/mole/mole.tscn
+++ b/scenes/mole/mole.tscn
@@ -235,9 +235,7 @@ data = ExtResource("2_615r7")
 
 [node name="AnimatedSprite2D" type="AnimatedSprite2D" parent="."]
 sprite_frames = SubResource("SpriteFrames_apu38")
-animation = &"hit"
-frame = 2
-frame_progress = 1.0
+animation = &"idle"
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
 position = Vector2(0, -4)

--- a/scenes/mole/mole.tscn
+++ b/scenes/mole/mole.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=37 format=3 uid="uid://cwosug7qr3qqs"]
+[gd_scene load_steps=50 format=3 uid="uid://cwosug7qr3qqs"]
 
 [ext_resource type="Texture2D" uid="uid://3000pe1233s5" path="res://assets/mole-hole/mole-hole.png" id="1_5ngfp"]
 [ext_resource type="Script" path="res://scripts/mole/mole.gd" id="1_khpre"]
@@ -64,6 +64,58 @@ region = Rect2(384, 0, 128, 128)
 [sub_resource type="AtlasTexture" id="AtlasTexture_54mrc"]
 atlas = ExtResource("3_gv1bf")
 region = Rect2(512, 0, 128, 128)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_vj8lw"]
+atlas = ExtResource("1_5ngfp")
+region = Rect2(384, 0, 128, 128)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_jfs6f"]
+atlas = ExtResource("1_5ngfp")
+region = Rect2(256, 0, 128, 128)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_sk2qy"]
+atlas = ExtResource("1_5ngfp")
+region = Rect2(128, 0, 128, 128)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_2ytve"]
+atlas = ExtResource("1_5ngfp")
+region = Rect2(0, 0, 128, 128)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_jd8lq"]
+atlas = ExtResource("2_os357")
+region = Rect2(384, 0, 128, 128)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_3lcv0"]
+atlas = ExtResource("2_os357")
+region = Rect2(256, 0, 128, 128)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_a4t8w"]
+atlas = ExtResource("2_os357")
+region = Rect2(128, 0, 128, 128)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_ujc7s"]
+atlas = ExtResource("2_os357")
+region = Rect2(0, 0, 128, 128)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_h6wuh"]
+atlas = ExtResource("1_5ngfp")
+region = Rect2(512, 0, 128, 128)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_jxe2i"]
+atlas = ExtResource("1_5ngfp")
+region = Rect2(384, 0, 128, 128)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_p1eva"]
+atlas = ExtResource("1_5ngfp")
+region = Rect2(256, 0, 128, 128)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_ayyrg"]
+atlas = ExtResource("1_5ngfp")
+region = Rect2(128, 0, 128, 128)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_fvsmu"]
+atlas = ExtResource("1_5ngfp")
+region = Rect2(0, 0, 128, 128)
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_0xbpt"]
 atlas = ExtResource("1_5ngfp")
@@ -162,6 +214,50 @@ animations = [{
 }, {
 "duration": 1.0,
 "texture": SubResource("AtlasTexture_54mrc")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_vj8lw")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_jfs6f")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_sk2qy")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_2ytve")
+}],
+"loop": false,
+"name": &"defeated",
+"speed": 12.0
+}, {
+"frames": [{
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_jd8lq")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_3lcv0")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_a4t8w")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_ujc7s")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_h6wuh")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_jxe2i")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_p1eva")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_ayyrg")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_fvsmu")
 }],
 "loop": false,
 "name": &"disappear",

--- a/scenes/mole/mole.tscn
+++ b/scenes/mole/mole.tscn
@@ -343,3 +343,5 @@ one_shot = true
 [node name="AttackTimer" type="Timer" parent="."]
 
 [connection signal="animation_finished" from="AnimatedSprite2D" to="." method="_on_animation_finished"]
+[connection signal="timeout" from="DisappearTimer" to="." method="_disappear"]
+[connection signal="timeout" from="AttackTimer" to="." method="_on_attack_timer_timeout"]

--- a/scripts/mole/mole.gd
+++ b/scripts/mole/mole.gd
@@ -15,11 +15,9 @@ class_name Mole extends CharacterBody2D
 @onready var attack_timer: Timer = $AttackTimer
 @onready var collision_shape: CollisionShape2D = $CollisionShape2D
 
-
 ## Callback function intended to be called when hit by the player's mallet.
 func on_hit() -> void:
 	# TODO: refactor this to take a damage value when powerups are implemented
-	animated_sprite.stop()
 	animated_sprite.play("hit")
 	apply_damage(100)
 
@@ -77,10 +75,6 @@ func _on_attack_timer_timeouted() -> void:
 
 func _disappear() -> void:
 	collision_shape.set_deferred("disabled", true)
-
-	animated_sprite.stop()
-	# TODO: replace the animation with one that does
-	#		indicate that the mole was hit
 	animated_sprite.play("disappear")
 
 

--- a/scripts/mole/mole.gd
+++ b/scripts/mole/mole.gd
@@ -68,9 +68,12 @@ func _on_animation_finished() -> void:
 		_:
 			animated_sprite.play("idle")
 
-func _on_attack_timer_timeouted() -> void:
+
+func _on_attack_timer_timeout() -> void:
 	game_state_manager.apply_damage(attack_damage)
-	animated_sprite.play("attack")
+	# Only attack if the mole isn't already in the middle of disappearing
+	if animated_sprite.animation != "disappear":
+		animated_sprite.play("attack")
 
 
 func _disappear() -> void:

--- a/scripts/mole/mole.gd
+++ b/scripts/mole/mole.gd
@@ -15,17 +15,16 @@ class_name Mole extends CharacterBody2D
 ## Callback function intended to be called when hit by the player's mallet.
 func on_hit() -> void:
 	# TODO: refactor this to take a damage value when powerups are implemented
-	animated_sprite.play("hit")
-	apply_damage(100)
+	apply_damage(50)
+	# Play the appropriate animation
+	if current_health == 0: animated_sprite.play("defeated")
+	else: animated_sprite.play("hit")
 
-
-# TODO: respond appropriately to mole's health.
-# 		health > 0: mole flash animation
-#		health == 0: mole died animation
 
 func apply_damage(value: int) -> void:
 	current_health = max(0, current_health - value)
 	if current_health == 0: _defeat()
+
 
 func _ready() -> void:
 	assert(data != null)
@@ -58,8 +57,6 @@ var attack_damage: int:
 ## and sets the next animation appropriately.
 func _on_animation_finished() -> void:
 	match animated_sprite.animation:
-		"hit":
-			if current_health == 0: animated_sprite.play("defeated")
 		"disappear", "defeated":
 			queue_free()
 		_:

--- a/scripts/mole/mole.gd
+++ b/scripts/mole/mole.gd
@@ -40,9 +40,6 @@ func _ready() -> void:
 
 	_load_data()
 
-	disappear_timer.timeout.connect(_disappear)
-	attack_timer.timeout.connect(_on_attack_timer_timeouted)
-
 	disappear_timer.start()
 	attack_timer.start()
 

--- a/scripts/mole/mole.gd
+++ b/scripts/mole/mole.gd
@@ -34,9 +34,6 @@ func apply_damage(value: int) -> void:
 
 func _ready() -> void:
 	assert(data != null)
-	assert(disappear_timer != null)
-	assert(attack_timer != null)
-	assert(collision_shape != null)
 
 	_load_data()
 

--- a/scripts/mole/mole.gd
+++ b/scripts/mole/mole.gd
@@ -62,8 +62,8 @@ var attack_damage: int:
 func _on_animation_finished() -> void:
 	match animated_sprite.animation:
 		"hit":
-			if current_health == 0: animated_sprite.play("disappear")
-		"disappear":
+			if current_health == 0: animated_sprite.play("defeated")
+		"disappear", "defeated":
 			queue_free()
 		_:
 			animated_sprite.play("idle")

--- a/scripts/mole/mole.gd
+++ b/scripts/mole/mole.gd
@@ -64,16 +64,17 @@ func _on_animation_finished() -> void:
 
 
 func _on_attack_timer_timeout() -> void:
-	game_state_manager.apply_damage(attack_damage)
-	# Only attack if the mole isn't already in the middle of disappearing
-	if animated_sprite.animation != "disappear":
+	# Only attack if the mole isn't already in the middle of another animation
+	if animated_sprite.animation == "idle":
+		game_state_manager.apply_damage(attack_damage)
 		animated_sprite.play("attack")
 
 
 func _disappear() -> void:
-	# Make sure we don't monitor for collisions and interrupt this
-	collision_shape.set_deferred("disabled", true)
-	animated_sprite.play("disappear")
+	if animated_sprite.animation == "idle":
+		# Make sure we don't monitor for collisions and interrupt this
+		collision_shape.set_deferred("disabled", true)
+		animated_sprite.play("disappear")
 
 
 func _defeat() -> void:

--- a/scripts/mole/mole.gd
+++ b/scripts/mole/mole.gd
@@ -2,10 +2,7 @@ class_name Mole extends CharacterBody2D
 ## mole.gd: Represents the mole enemy character
 ##			Interface includes: controlling the mole, interaction with its stats.
 ##
-## Author(s): Tessa Power, Phuwasate Lutchanont
-
-# TODO: mole doesnt hit
-# TODO: mole doesnt disappear
+## Author(s): Phuwasate Lutchanont, Tessa Power
 
 ## Animations
 @export var data: MoleData
@@ -77,11 +74,13 @@ func _on_attack_timer_timeout() -> void:
 
 
 func _disappear() -> void:
+	# Make sure we don't monitor for collisions and interrupt this
 	collision_shape.set_deferred("disabled", true)
 	animated_sprite.play("disappear")
 
 
 func _defeat() -> void:
+	# Make sure we don't monitor for collisions and interrupt this
 	collision_shape.set_deferred("disabled", true)
 	game_state_manager.add_exp(exp_reward)
 	game_state_manager.add_score(score_reward)


### PR DESCRIPTION
Merging this PR will:

- Set the mole's default animation to "idle".
- Rename the "disappear" animation to "defeated".
- Introduce a dedicated "disappear" animation.
- Ensure the mole animations are called appropriately so they do not interrupt each other, namely so that a mole won't start trying to disappear while it is attacking or reacting to getting hit.
- Ensure the mole responds to getting hit with the appropriate animation ("hit" if health > 0, otherwise "defeated").

 