### PR TITLE
Fix bug where mallets in desert and underwater levels were unresponsive

### DIFF
--- a/scenes/mallet/mallet.tscn
+++ b/scenes/mallet/mallet.tscn
@@ -48,7 +48,6 @@ _data = {
 [node name="BasicMallet" type="Node2D"]
 position = Vector2(772, 467)
 script = ExtResource("1_hma0e")
-attack_speed = 2.0
 
 [node name="HitArea" type="Area2D" parent="."]
 

--- a/scenes/mallet/revolver_mallet.tscn
+++ b/scenes/mallet/revolver_mallet.tscn
@@ -66,4 +66,3 @@ texture = ExtResource("2_i8vs7")
 libraries = {
 "": SubResource("AnimationLibrary_mq7oj")
 }
-speed_scale = 4.0

--- a/scenes/mallet/shell_mallet.tscn
+++ b/scenes/mallet/shell_mallet.tscn
@@ -65,4 +65,3 @@ texture = ExtResource("2_4c1d8")
 libraries = {
 "": SubResource("AnimationLibrary_mq7oj")
 }
-speed_scale = 4.0

--- a/scripts/mallet/mallet.gd
+++ b/scripts/mallet/mallet.gd
@@ -13,7 +13,7 @@ const ATTACK_BUFFER_TIMEOUT := 0.5
 @onready var anim_player: AnimationPlayer = $AnimationPlayer
 @onready var hit_area: Area2D = $HitArea
 
-@export var attack_speed: float
+@export var attack_speed: float = 2.0
 
 @onready var anim_length: float = anim_player.get_animation("attack").length
 


### PR DESCRIPTION
Merging this PR will fix a bug where the mallets in the desert and underwater levels were unresponsive to player clicks. The animation speed scale for the desert and underwater mallets was set to 4 and attack speed was set to 0 (no default value assigned in the script), while the normal mallet had animation speed scale of 1 and attack speed of 2 (overridden in the grassy field level scene)